### PR TITLE
Fix FuzzPathClean test to handle Windows UNC paths

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -82,8 +82,14 @@ func FuzzPathClean(f *testing.F) {
 		}
 
 		// Property 5: Result should not have trailing separator unless it's root
+		// On Windows, UNC paths like "\\\\" are valid roots and can have multiple separators
 		if len(cleaned) > 1 && cleaned[len(cleaned)-1] == filepath.Separator {
-			t.Errorf("has trailing separator: %q → %q", path, cleaned)
+			// Check if this is a valid root path
+			isRoot := cleaned == string(filepath.Separator) ||
+				(len(cleaned) >= 2 && cleaned[0] == '\\' && cleaned[1] == '\\' && strings.TrimRight(cleaned, string(filepath.Separator)) == "")
+			if !isRoot {
+				t.Errorf("has trailing separator: %q → %q", path, cleaned)
+			}
 		}
 
 		// Property 6: No double separators in result


### PR DESCRIPTION
## Summary
- Fixed FuzzPathClean test failing on Windows due to UNC path handling
- Added logic to recognize Windows UNC paths as valid root paths

## Background
The test was failing on Windows because filepath.Clean converts paths like // and /// to UNC paths. These are valid root paths on Windows (network share roots) and can legitimately have trailing separators.
